### PR TITLE
Fix for is_close error in main.cc

### DIFF
--- a/02_Basics/TimeConverter/Solution/main.cc
+++ b/02_Basics/TimeConverter/Solution/main.cc
@@ -1,8 +1,14 @@
 #include <cassert>
 #include <iostream>
+#include <cmath>
+#include <limits>
 
 #include "lib.h"
-#include "utils.hpp"
+
+template <typename T>
+bool is_close(T a, T b, T tolerance = std::numeric_limits<T>::epsilon()) {
+    return std::abs(a - b) <= tolerance;
+}
 
 void test_cases();
 


### PR DESCRIPTION
### **Problem:**
I encountered an error while attempting to run the C++ program "TimeConverter." The _is_close_ function in the _main.cc_ file seemed to malfunction, leading to compilation errors. Additionally, the required file _utils.hpp_, referenced in the header, was missing.

### **Solution:**
I redefined the _isClose_ function. It now accepts an optional tolerance (by default, the smallest positive value representable by the floating-point number of type T) and checks if the absolute difference between the two numbers is less than or equal to the tolerance.

**Detailed Changes:**

Redefinition of _isClose_:

The _isClose_ function has been revised to accept an optional tolerance, allowing for more precise comparison of floating-point numbers.

